### PR TITLE
Fix defined() on non-scalar deprecation warnings

### DIFF
--- a/sqlog
+++ b/sqlog
@@ -456,10 +456,8 @@ sub read_config
         # enable / disable per job node tracking
         $conf{track} = $conf::TRACKNODES if (defined $conf::TRACKNODES);
 
-        if (defined %conf::FORMATS) {
-            for my $key (keys %conf::FORMATS) {
-                $conf{format_list}{$key} = $conf::FORMATS{$key};
-            }
+        for my $key (keys %conf::FORMATS) {
+            $conf{format_list}{$key} = $conf::FORMATS{$key};
         }
     }
 

--- a/sqlog-db-util
+++ b/sqlog-db-util
@@ -412,7 +412,7 @@ sub read_config
     $conf{rw}{rootpass}   = $conf::SQLROOTPASS if (defined $conf::SQLROOTPASS);
     $conf{rw}{sqlnetwork} = $conf::SQLNETWORK  if (defined $conf::SQLNETWORK);
 
-    @{$conf{rw}{hosts}} = @conf::SQLRWHOSTS if (defined @conf::SQLRWHOSTS);
+    @{$conf{rw}{hosts}} = @conf::SQLRWHOSTS if (@conf::SQLRWHOSTS);
 
     my %seen;
     @{$conf{rw}{hosts}} = grep {$_ && !$seen{$_}++} @{$conf{rw}{hosts}};


### PR DESCRIPTION
Remove the use of defined() on arrays and hashes.  This has been
deprecated in newer perl versions (e.g. 5.16) and reports a warning when
used.  For example:

  defined(%hash) is deprecated at /usr/bin/sqlog line 459.
          (Maybe you should just omit the defined()?)
